### PR TITLE
Fix use-after-free and out-of-bounds access memory errors

### DIFF
--- a/client.c
+++ b/client.c
@@ -53,7 +53,7 @@ int n_clients = 0;
 #else
 #define NO_INVALID_ADDRESSES 1
 #endif
-static struct sockaddr invalidAddresses[NO_INVALID_ADDRESSES];
+static struct sockaddr_storage invalidAddresses[NO_INVALID_ADDRESSES];
 
 #if defined(HAVE_FORK) && !defined(HAVE_THREADS)
 
@@ -221,9 +221,9 @@ void clientmgr (void *arg)
   UNUSED_ARG(arg);
 
   /* Initialize invalid addresses. static variables are guaranteed to be initialized to 0, so no need to specify all members */
-  invalidAddresses[0].sa_family = AF_INET;
+  invalidAddresses[0].ss_family = AF_INET;
 #ifdef AF_INET6
-  invalidAddresses[1].sa_family = AF_INET6;
+  invalidAddresses[1].ss_family = AF_INET6;
 #endif
 
 #ifdef HAVE_THREADS
@@ -479,15 +479,15 @@ static int call0 (FTN_NODE *node, BINKD_CONFIG *config)
     for (ai = aiHead; ai != NULL && sockfd == INVALID_SOCKET; ai = ai->ai_next)
     {
       for (j = 0; j < NO_INVALID_ADDRESSES; j++)
-        if (0 == sockaddr_cmp_addr(ai->ai_addr, &invalidAddresses[j]))
+        if (0 == sockaddr_cmp_addr(ai->ai_addr, (struct sockaddr *)&invalidAddresses[j]))
         {
 #ifdef AF_INET6
-          const int l = invalidAddresses[j].sa_family == AF_INET6 
+          const int l = invalidAddresses[j].ss_family == AF_INET6
                       ? sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
 #else
           const int l = sizeof(struct sockaddr_in);
 #endif
-          rc = getnameinfo( &invalidAddresses[j], l, addrbuf, sizeof(addrbuf)
+          rc = getnameinfo( (struct sockaddr *)&invalidAddresses[j], l, addrbuf, sizeof(addrbuf)
                           , NULL, 0, NI_NUMERICHOST );
           if (rc != 0)
             Log(2, "Error in getnameinfo(): %s (%d)", gai_strerror(rc), rc);

--- a/client.c
+++ b/client.c
@@ -304,7 +304,7 @@ static int call0 (FTN_NODE *node, BINKD_CONFIG *config)
   char addrbuf[BINKD_FQDNLEN + 1];
   char servbuf[MAXSERVNAME + 1];
   char *hosts;
-  char *port;
+  char port[MAXPORTSTRLEN + 1] = { 0 };
   char *dst_ip = NULL;
   const char *save_err;
 #ifdef HTTPS
@@ -392,7 +392,7 @@ static int call0 (FTN_NODE *node, BINKD_CONFIG *config)
 
   for (i = 1; sockfd == INVALID_SOCKET
        && (rc = get_host_and_port
-           (i, host, &port, hosts, &node->fa, config)) != -1; ++i)
+           (i, host, port, hosts, &node->fa, config)) != -1; ++i)
   {
     if (rc == 0)
     {
@@ -534,7 +534,7 @@ static int call0 (FTN_NODE *node, BINKD_CONFIG *config)
       {
         char *sp = strchr(host, ':');
         if (sp) *sp = '\0';
-        if (port == config->oport)
+        if (strcmp (port, config->oport) == 0)
           Log (4, "trying %s via %s %s:%s...", host,
                proxy[0] ? "proxy" : "socks", addrbuf, servbuf);
         else
@@ -544,12 +544,12 @@ static int call0 (FTN_NODE *node, BINKD_CONFIG *config)
       else
 #endif
       {
-        if (port == config->oport)
+        if (strcmp (port, config->oport) == 0)
           Log (4, "trying %s [%s]...", host, addrbuf);
         else
           Log (4, "trying %s [%s]:%s...", host, addrbuf, servbuf);
         dst_ip = addrbuf;
-        port = servbuf;
+        strnzcpy (port, servbuf, MAXPORTSTRLEN);
       }
       /* find bind addr with matching address family */
       if (config->bindaddr[0])

--- a/ftnnode.c
+++ b/ftnnode.c
@@ -237,7 +237,7 @@ static FTN_NODE *get_defnode_info(FTN_ADDR *fa, FTN_NODE *on, BINKD_CONFIG *conf
   int aiErr;
   FTN_NODE n, *np;
   char host[BINKD_FQDNLEN + 1];       /* current host/port */
-  char *port;
+  char port[MAXPORTSTRLEN + 1] = { 0 };
   int i;
 
   /* setup hints for getaddrinfo */
@@ -253,12 +253,12 @@ static FTN_NODE *get_defnode_info(FTN_ADDR *fa, FTN_NODE *on, BINKD_CONFIG *conf
   if (!np) /* we don't have defnode info */
     return on;
 
-  for (i=1; np->hosts && get_host_and_port(i, host, &port, np->hosts, fa, config)==1; i++)
+  for (i=1; np->hosts && get_host_and_port(i, host, port, np->hosts, fa, config)==1; i++)
   {
     if (!strcmp(host, "-"))
       continue;
 
-    aiErr = srv_getaddrinfo(host, port ? port : NULL, &hints, &ai);
+    aiErr = srv_getaddrinfo(host, port[0] ? port : NULL, &hints, &ai);
     if (aiErr != 0) continue;
     freeaddrinfo(ai);
     sprintf (host+strlen(host), ":%s", port);

--- a/iphdr.h
+++ b/iphdr.h
@@ -71,6 +71,8 @@
   #define MAXSERVNAME 80                    /* max id len in /etc/services */
 #endif
 
+#define MAXPORTSTRLEN 32
+
 #ifndef HAVE_SOCKLEN_T
   typedef int socklen_t;
 #endif

--- a/protocol.c
+++ b/protocol.c
@@ -1159,7 +1159,7 @@ static int ADR (STATE *state, char *s, int sz, BINKD_CONFIG *config)
       int ipok = 0;
 #endif
       char host[BINKD_FQDNLEN + 1];       /* current host/port */
-      char *port;
+      char port[MAXPORTSTRLEN + 1] = { 0 };
       struct sockaddr_storage sin;
       struct addrinfo *ai, *aiHead, hints;
       int aiErr;
@@ -1202,7 +1202,7 @@ static int ADR (STATE *state, char *s, int sz, BINKD_CONFIG *config)
 #endif
 
       for (i = 1; pn->hosts &&
-           (rc = get_host_and_port(i, host, &port, pn->hosts, &pn->fa, config)) != -1; ++i)
+           (rc = get_host_and_port(i, host, port, pn->hosts, &pn->fa, config)) != -1; ++i)
       {
         if (rc == 0)
         {

--- a/readcfg.c
+++ b/readcfg.c
@@ -1285,10 +1285,11 @@ static int read_node_info (KEYWORD *key, int wordcount, char **words)
  *
  *  Returns 0 on error, -1 on EOF, 1 otherwise
  */
-int get_host_and_port (int n, char *host, char **port, char *src, FTN_ADDR *fa, BINKD_CONFIG *config)
+int get_host_and_port (int n, char *host, char *port, char *src, FTN_ADDR *fa, BINKD_CONFIG *config)
 {
   int rc = 0;
   char *s = getwordx2 (src, n, 0, ",;", "");
+  char *p = NULL;
 
   if (s)
   {
@@ -1316,11 +1317,13 @@ int get_host_and_port (int n, char *host, char **port, char *src, FTN_ADDR *fa, 
 
     if (!t)
     {
-      *port = config->oport;
+      strnzcpy (port, config->oport, MAXPORTSTRLEN);
       rc = 1;
     }
-    else if ((*port = find_port (t + 1)) != 0)
+    else if ((p = find_port(t + 1)) != NULL) {
+      strnzcpy (port, p, MAXPORTSTRLEN);
       rc = 1;
+    }
 
     free (s);
   }

--- a/readcfg.h
+++ b/readcfg.h
@@ -261,7 +261,7 @@ void simplelist_free(struct list_linkpoint *lp, void (*destructor)(void *));
  */
 void destroy_maskchain(void *p);
 
-int  get_host_and_port (int n, char *host, char **port, char *src, FTN_ADDR *fa, BINKD_CONFIG *config);
+int  get_host_and_port (int n, char *host, char *port, char *src, FTN_ADDR *fa, BINKD_CONFIG *config);
 
 char *mask_test(char *s, struct maskchain *chain);
 


### PR DESCRIPTION
Don't use pointer assignment in this function,
but copy into a fixed-length buffer instead.

Fixes #15

Also fix an out-of-bounds bug in accessing the
`invalidAddresses` array.

Signed-off-by: Dan Cross <cross@fat-dragon.org>