### PR TITLE
Fix build for OS/2 and Windows 9x on ancient compilers

### DIFF
--- a/ftnq.c
+++ b/ftnq.c
@@ -270,7 +270,7 @@ static FTNQ *q_scan_box (FTNQ *q, FTN_ADDR *fa, char *boxpath, char flvr, int de
       sb.st_mtime = 0; /* ??? val: don't know how to get it if stat() isn't used */
       strnzcat (buf, de->d_name, sizeof (buf));
       if (de->d_name[0] != '.'
-#if defined(_MSC_VER) || defined(DOS)
+#if defined(_MSC_VER) || defined(DOS) && !defined(DJGPP)
           && (de->d_attrib & 0x1a) == 0 /* not hidden, directory or volume label */
 #elif defined(OS2) && !defined(IBMC) && !defined(__WATCOMC__)
           && (de->d_attr & 0x1a) == 0   /* not hidden, directory or volume label */

--- a/mkfls/dos-djgpp/Makefile
+++ b/mkfls/dos-djgpp/Makefile
@@ -1,0 +1,285 @@
+# $Id$
+#
+
+# Usage: make [DEBUG=1] [BINKD9X=1] [PERL=1] [PERLDL=1]
+#	      [ZLIB=1] [BZLIB2=1] [ZLIBDL=1] [DEBUGCHILD=1]
+#	      [IPV6=1] [FTS5004=1] [BW_LIM=1] [AF_FORCE=1]
+#
+#
+
+#PERL_BASE=c:/Perl
+#PERL_LIB=perl58
+
+#ZLIB_BASE=../zlib
+#ZLIB_LIB=z
+#BZLIB2_BASE=../bzlib2
+#BZLIB2_LIB=bz2
+
+#WATT_ROOT=../watt32
+#WATT_LIB=watt
+
+# =============================================================================
+
+# WINDRES?=windres
+
+OUTDIR=bin/dos
+BINKDNAME=binkd-dos-djgpp
+BINKDTYPE=djgpp
+
+CC=gcc
+CFLAGS+= -funsigned-char \
+	 -Wall -Wno-char-subscripts -Wno-comment \
+	 -I $(WATT_ROOT)\inc
+
+CDEFS+=  -DDOS -DHAVE_UNISTD -DHAVE_INTTYPES_H -DHAVE_INTMAX_T \
+	 -DHAVE_IO_H -DHAVE_DOS_H -DHAVE_STDARG_H -DHAVE_NETINET_IN_H -DHAVE_NETDB_H  \
+	 -DHTTPS -DNTLM -DHAVE_SNPRINTF -DHAVE_VSNPRINTF -DHAVE_ARPA_INET_H \
+	 -DWATT32_NO_OLDIES -DHAVE_SOCKLEN_T
+
+
+
+
+SRCS= binkd.c readcfg.c tools.c ftnaddr.c ftnq.c client.c server.c protocol.c \
+      bsy.c inbound.c branch.c ftndom.c ftnnode.c srif.c pmatch.c readflo.c   \
+      prothlp.c iptools.c rfc2553.c run.c binlog.c exitproc.c getw.c xalloc.c \
+      setpttl.c https.c md5b.c crypt.c getopt.c  \
+      snprintf.c breaksig.c dos/getfree.c dos/sleep.c \
+      ntlm/ecb_enc.c ntlm/md4_dgst.c ntlm/set_key.c ntlm/des_enc.c	      \
+      ntlm/helpers.c
+
+LIBS+= -L $(WATT_ROOT)\lib -l$(WATT_LIB)
+
+#RES=  nt/binkdres.rc
+
+OBJDIR= $(OUTDIR)/obj
+MAKEDIRSONLY= $(OUTDIR)/obj $(OBJDIR)/ntlm $(OBJDIR)/dos
+MAKEDIRS= $(OUTDIR) $(MAKEDIRSONLY)
+
+# debug +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ifdef DEBUG
+CFLAGS+= -g
+CDEFS+= -DDEBUG -D_DEBUG
+BINKDNAME:=$(BINKDNAME)-debug
+OUTDIR:=$(OUTDIR)-debug
+BINKDTYPE:=$(BINKDTYPE), debug
+else
+CFLAGS+= -s -O2
+endif
+# debug (DEBUG) ---------------------------------------------------------------
+
+# debugchild, nofork ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ifdef DEBUGCHILD
+CDEFS+= -DDEBUGCHILD
+BINKDNAME:=$(BINKDNAME)-debugchild
+OUTDIR:=$(OUTDIR)-debugchild
+BINKDTYPE:=$(BINKDTYPE), debugchild
+endif
+# debugchild, nofork ----------------------------------------------------------
+
+# bandwidth limiting ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ifdef BW_LIM
+CDEFS+= -DBW_LIM=1
+endif
+# bandwidth limiting ----------------------------------------------------------
+
+# soft AF force +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ifdef AF_FORCE
+CDEFS+= -DAF_FORCE=1
+endif
+# soft AF force ---------------------------------------------------------------
+
+# perl support ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# PERLDL implies PERL
+ifdef PERLDL
+ifndef PERL
+PERL=1
+endif
+endif
+
+ifdef PERL
+
+ifndef PERL_BASE
+PERL_BASE=${shell perl -mConfig -e 'print $$Config::Config{prefix};'}
+endif
+
+ifdef PERL_BASE
+PERL_INCL=$(PERL_BASE)/lib/CORE
+else
+PERL_INCL=${shell perl -mConfig -e '$$_ = $$Config::Config{libpth}; s!^\"!!; s!\"$$!!; !s!\\!/!g; print;'}
+endif
+
+CDEFS+= -DWITH_PERL -DNDEBUG -DNO_STRICT -DHAVE_DES_FCRYPT -DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -DPERL_MSVCRT_READFIX
+SRCS+= perlhooks.c
+C_DIRS+= -idirafter "$(PERL_INCL)"
+
+ifdef PERLDL
+CDEFS+= -DPERLDL
+CFLAGS+= -fno-strict-aliasing
+BINKDNAME:=$(BINKDNAME)-perldl
+OUTDIR:=$(OUTDIR)-perldl
+BINKDTYPE:=$(BINKDTYPE), perldl
+else
+
+ifndef PERL_LIB
+PERL_LIB=${shell perl -mConfig -e '($$_ = $$Config::Config{libperl}) =~ s!\.lib$$!!i; print;'}
+endif
+
+L_DIRS+= -L"$(PERL_INCL)"
+LIBS+= -l$(PERL_LIB)
+BINKDNAME:=$(BINKDNAME)-perl
+OUTDIR:=$(OUTDIR)-perl
+BINKDTYPE:=$(BINKDTYPE), perl
+endif
+endif
+# perl support ----------------------------------------------------------------
+
+# zlib support ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ifdef ZLIB
+CDEFS+= -DWITH_ZLIB
+ZLIB_BZLIB2=1
+
+ifdef ZLIB_BASE
+C_DIRS+= -I "$(ZLIB_BASE)"
+L_DIRS+= -L "$(ZLIB_BASE)"
+endif
+
+ifndef ZLIBDL
+ifndef ZLIB_LIB
+ZLIB_LIB=z
+endif
+LIBS+= -l"$(ZLIB_LIB)"
+BINKDNAME:=$(BINKDNAME)-zlib
+OUTDIR:=$(OUTDIR)-zlib
+BINKDTYPE:=$(BINKDTYPE), zlib
+else
+BINKDNAME:=$(BINKDNAME)-zlibdl
+OUTDIR:=$(OUTDIR)-zlibdl
+BINKDTYPE:=$(BINKDTYPE), zlibdl
+endif
+endif
+# zlib support ----------------------------------------------------------------
+
+# bzlib2 support ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ifdef BZLIB2
+CDEFS+= -DWITH_BZLIB2
+ZLIB_BZLIB2=1
+
+ifdef BZLIB2_BASE
+C_DIRS+= -I "$(BZLIB2_BASE)"
+L_DIRS+= -L "$(BZLIB2_BASE)"
+endif
+
+ifndef ZLIBDL
+ifndef BZLIB2_LIB
+BZLIB2_LIB=bz2
+endif
+LIBS+= -l"$(BZLIB2_LIB)"
+BINKDNAME:=$(BINKDNAME)-bzlib2
+OUTDIR:=$(OUTDIR)-bzlib2
+BINKDTYPE:=$(BINKDTYPE), bzlib2
+else
+BINKDNAME:=$(BINKDNAME)-bzlib2dl
+OUTDIR:=$(OUTDIR)-bzlib2dl
+BINKDTYPE:=$(BINKDTYPE), bzlib2dl
+endif
+endif
+# bzlib2 support --------------------------------------------------------------
+
+# zlib & bzlib2 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ifdef ZLIB_BZLIB2
+ifdef ZLIBDL
+CDEFS+= -DZLIBDL
+SRCS+= zlibdl.c
+endif
+SRCS+= compress.c
+endif
+# zlib & bzlib2 ---------------------------------------------------------------
+
+BINKDEXE = $(BINKDNAME).exe
+
+OBJS=$(addprefix $(OBJDIR)/,$(patsubst %.c,%.o, $(SRCS)))
+RESOBJS=$(addprefix $(OBJDIR)/, $(patsubst %.rc,%.o, $(RES)))
+
+.PHONY: all printinfo install html clean distclean makedirs
+
+all: printinfo makedirs $(OUTDIR)/$(BINKDEXE)
+
+printinfo:
+	@echo "-----------------------------------------------------------"
+	@echo "binkd type : $(BINKDTYPE)"
+	@echo "output dir : $(OUTDIR)"
+	@echo "binkd exe  : $(BINKDEXE)"
+	@echo "DEPS : $(DEPS)"
+ifdef PERL
+	@echo "perlincl   : $(PERL_INCL)"
+ifndef PERLDL
+	@echo "perllib	  : $(PERL_LIB)"
+endif
+endif
+ifdef ZLIB
+ifdef ZLIB_BASE
+	@echo "zlibincl   : $(ZLIB_BASE)"
+endif
+ifndef ZLIBDL
+	@echo "zliblib	  : $(ZLIB_LIB)"
+endif
+endif
+ifdef BZLIB2
+ifdef BZLIB2_BASE
+	@echo "bzlib2incl : $(BZLIB2_BASE)"
+endif
+ifndef ZLIBDL
+	@echo "bzlib2lib  : $(BZLIB2_LIB)"
+endif
+endif
+	@echo "-----------------------------------------------------------"
+
+$(OBJDIR)/%.o: %.c
+	@echo Compiling $<...
+	@$(CC) -c -MMD $(CFLAGS) $(CDEFS) $(C_DIRS) -o $@ $<
+
+$(OBJDIR)/%.o: %.rc
+	@echo Compiling $<...
+	$(WINDRES) $(CDEFS) -D"BINKDNAME=$(BINKDNAME)" -D"BINKDEXE=$(BINKDEXE)" $< $@
+
+$(OUTDIR)/$(BINKDEXE): $(OBJS) $(RESOBJS)
+	@echo Linking $(BINKDEXE)...
+	@$(CC) $(CFLAGS) $(LFLAGS) $(L_DIRS) -o $@ $(OBJS) $(RESOBJS) $(LIBS)
+
+makedirs: $(MAKEDIRS)
+
+$(MAKEDIRS):
+	@echo Making directory $@...
+	@mkdir $@
+
+install: all clean
+
+html: binkd.html
+
+binkd.html: binkd.8
+	groff -Thtml -mman binkd.8 >$(OUTDIR)/binkd.html
+
+#
+# Cleanup
+
+CLEANEXT:= *.o *.d
+
+clean:
+	@echo Cleanup...
+	del /f /q $(foreach dir,$(MAKEDIRSONLY),$(foreach ext,$(CLEANEXT),$(dir)\\$(ext)))
+
+distclean:
+	@echo Full cleanup...
+	rmdir /s /q $(OUTDIR)
+
+#
+# Dependencies (idea taken from zlib makefile)
+
+DEPS:=$(foreach dir,$(MAKEDIRSONLY),$(wildcard $(dir)/*.d))
+
+ifneq ($(DEPS),)
+include $(DEPS)
+endif
+
+# Dependencies for resourses
+$(RESOBJS): Config.h confopt.h

--- a/mkfls/os2-emx/Makefile
+++ b/mkfls/os2-emx/Makefile
@@ -1,7 +1,7 @@
 # $Id$
 #
 # Usage: make [DEBUG=1] [NOFORK=1] [PERL=1] [PERLDL=1]
-#             [ZLIB=1] [BZLIB2=1] [ZLIBDL=1] [BW_LIM=1]
+#	      [ZLIB=1] [BZLIB2=1] [ZLIBDL=1] [BW_LIM=1]
 #
 # Tested with perl 5.0053
 #
@@ -13,10 +13,15 @@ CFLAGS=$(DEFINES) -Wall -funsigned-char -Wno-char-subscripts
 LFLAGS=-Los2
 LIBS=-lsocket -lresolv
 NTLM_SRC=ntlm/des_enc.c ntlm/helpers.c ntlm/ecb_enc.c ntlm/md4_dgst.c ntlm/set_key.c
-SRCS=binkd.c readcfg.c tools.c ftnaddr.c ftnq.c client.c server.c protocol.c bsy.c inbound.c breaksig.c branch.c os2/gettid.c os2/sem.c  ftndom.c ftnnode.c os2/getfree.c srif.c pmatch.c readflo.c prothlp.c iptools.c rfc2553.c run.c binlog.c exitproc.c getw.c xalloc.c setpttl.c https.c md5b.c crypt.c srv_gai.c os2/ns_parse.c ${NTLM_SRC}
-TARGET=binkd2e.exe
+SRCS=binkd.c readcfg.c tools.c ftnaddr.c ftnq.c client.c server.c protocol.c bsy.c inbound.c breaksig.c branch.c os2/gettid.c os2/sem.c ftndom.c ftnnode.c os2/getfree.c srif.c pmatch.c readflo.c prothlp.c iptools.c rfc2553.c run.c binlog.c exitproc.c getw.c xalloc.c setpttl.c https.c md5b.c crypt.c srv_gai.c os2/ns_parse.c ${NTLM_SRC}
+TARGET=binkd2emx
+
+#PERLDIR=../perl5.00553/os2
+#ZLIB_DIR=../zlib-1.2.11
+#BZLIB2_DIR=../bzip2-1.0.6
 
 ifdef DEBUG
+TARGET:=$(TARGET)-debug
 CFLAGS+=-g -DDEBUG
 LFLAGS+=-g
 else
@@ -25,30 +30,37 @@ LFLAGS+=-O2 -s
 endif
 
 ifdef NOFORK
+TARGET:=$(TARGET)-nofork
 CFLAGS+=-DDEBUGCHILD
 endif
 
 ifdef PERLDL
+TARGET:=$(TARGET)-perldl
+ifndef PERLDIR
 PERLDIR=$(shell perl -MConfig -e "print $$Config{archlib}")
+endif
 CFLAGS+= -Zmt -DWITH_PERL -DPERLDL -DDOSISH -DPERL_IS_AOUT -DEMBED -I$(PERLDIR)/CORE
 LFLAGS+= -Zmt -Zcrtdll -Zstack 16000
 SRCS+= perlhooks.c
 else
 ifdef PERL
+TARGET:=$(TARGET)-perl
+ifndef PERLDIR
 PERLDIR=$(shell perl -MConfig -e "print $$Config{archlib}")
+endif
 CFLAGS+= -DWITH_PERL -DDOSISH -DPERL_IS_AOUT -DEMBED -I$(PERLDIR)/CORE
 LFLAGS+= -L$(PERLDIR)/CORE -Zsmall-conv -Zstack 16000
 LIBS:=$(PERLDIR)/auto/DB_File/DB_File.a \
-         $(PERLDIR)/auto/SDBM_File/SDBM_File.a \
-         $(PERLDIR)/auto/Fcntl/Fcntl.a \
-         $(PERLDIR)/auto/IO/IO.a \
-         $(PERLDIR)/auto/POSIX/POSIX.a \
-         $(PERLDIR)/auto/Socket/Socket.a \
-         $(PERLDIR)/auto/OS2/Process/Process.a \
-         $(PERLDIR)/auto/OS2/ExtAttr/ExtAttr.a \
-         $(PERLDIR)/auto/OS2/REXX/REXX.a \
-         $(PERLDIR)/auto/DynaLoader/DynaLoader.a \
-         -llibperl -lm -lbsd -ldb $(LIBS)
+	 $(PERLDIR)/auto/SDBM_File/SDBM_File.a \
+	 $(PERLDIR)/auto/Fcntl/Fcntl.a \
+	 $(PERLDIR)/auto/IO/IO.a \
+	 $(PERLDIR)/auto/POSIX/POSIX.a \
+	 $(PERLDIR)/auto/Socket/Socket.a \
+	 $(PERLDIR)/auto/OS2/Process/Process.a \
+	 $(PERLDIR)/auto/OS2/ExtAttr/ExtAttr.a \
+	 $(PERLDIR)/auto/OS2/REXX/REXX.a \
+	 $(PERLDIR)/auto/DynaLoader/DynaLoader.a \
+	 -llibperl -lm -lbsd -ldb $(LIBS)
 SRCS+= perlhooks.c
 else
 CFLAGS+= -Zcrtdll
@@ -60,12 +72,16 @@ ifdef ZLIB
 COMPRESS=1
 CFLAGS+= -DWITH_ZLIB=1
 ifdef ZLIB_DIR
-CFLAGS+= -I$(ZLIB_DIR)/include
+CFLAGS+= -I$(ZLIB_DIR)
 endif
 ifndef ZLIBDL
-LIBS:=-lz_s $(LIBS)
+TARGET:=$(TARGET)-zlib
+ifndef ZLIB_LIB
+ZLIB_LIB=z_s
+endif
+LIBS:=-l$(ZLIB_LIB) $(LIBS)
 ifdef ZLIB_DIR
-LFLAGS+= -L$(ZLIB_DIR)/lib
+LFLAGS+= -L$(ZLIB_DIR)
 endif
 endif
 endif
@@ -74,12 +90,16 @@ ifdef BZLIB2
 COMPRESS=1
 CFLAGS+= -DWITH_BZLIB2=1
 ifdef BZLIB2_DIR
-CFLAGS+= -I$(BZLIB2_DIR)/include
+CFLAGS+= -I$(BZLIB2_DIR)
 endif
 ifndef ZLIBDL
-LIBS:=-llibbz2_s $(LIBS)
+TARGET:=$(TARGET)-bzlib2
+ifndef BZLIB2_LIB
+BZLIB2_LIB=libbz2
+endif
+LIBS:=-l$(BZLIB2_LIB) $(LIBS)
 ifdef BZLIB2_DIR
-LFLAGS+= -L$(BZLIB2_DIR)/lib
+LFLAGS+= -L$(BZLIB2_DIR)
 endif
 endif
 endif
@@ -99,6 +119,8 @@ endif
 
 .SUFFIXES: .imp .a
 OBJS=${SRCS:.c=.o}
+
+TARGET:=$(TARGET).exe
 
 all: $(TARGET)
 

--- a/mkfls/os2-emx/Makefile.emo
+++ b/mkfls/os2-emx/Makefile.emo
@@ -9,9 +9,15 @@ CFLAGS=$(DEFINES) -Wall -Zomf -Zmt -funsigned-char -Wno-char-subscripts
 LFLAGS=-Zomf -Zcrtdll -Zmt -Zlinker /PM:VIO
 LIBS=-lsocket
 NTLM_SRC=ntlm/des_enc.c ntlm/helpers.c ntlm/ecb_enc.c ntlm/md4_dgst.c ntlm/set_key.c
-SRCS=binkd.c readcfg.c tools.c ftnaddr.c ftnq.c client.c server.c protocol.c bsy.c inbound.c breaksig.c branch.c os2/gettid.c os2/sem.c  ftndom.c ftnnode.c os2/getfree.c srif.c pmatch.c readflo.c prothlp.c iptools.c rfc2553.c run.c binlog.c exitproc.c getw.c xalloc.c setpttl.c https.c md5b.c crypt.c ${NTLM_SRC}
+SRCS=binkd.c readcfg.c tools.c ftnaddr.c ftnq.c client.c server.c protocol.c bsy.c inbound.c breaksig.c branch.c os2/gettid.c os2/sem.c ftndom.c ftnnode.c os2/getfree.c srif.c pmatch.c readflo.c prothlp.c iptools.c rfc2553.c run.c binlog.c exitproc.c getw.c xalloc.c setpttl.c https.c md5b.c crypt.c srv_gai.c os2/ns_parse.c ${NTLM_SRC}
+TARGET=binkd2emo
+
+#PERLDIR=../perl5.00553/os2
+#ZLIB_DIR=../zlib-1.2.11
+#BZLIB2_DIR=../bzip2-1.0.6
 
 ifdef DEBUG
+TARGET:=$(TARGET)-debug
 CFLAGS+=-g -DDEBUG
 LFLAGS+=-g
 else
@@ -20,13 +26,17 @@ LFLAGS+=-O2 -s
 endif
 
 ifdef NOFORK
+TARGET:=$(TARGET)-nofork
 CFLAGS+=-DDEBUGCHILD
 endif
 
 ifdef PERL
+TARGET:=$(TARGET)-perl
+ifndef PERLDIR
 PERLDIR=$(shell perl -MConfig -e "print $$Config{archlib}")
+endif
 CFLAGS+= -DWITH_PERL -DPERL_MULTITHREAD -DDOSISH -DEMBED -DOS2=2 \
-         -D_EMX_CRT_REV_=64 -I$(PERLDIR)/CORE
+	 -D_EMX_CRT_REV_=64 -I$(PERLDIR)/CORE
 #CFLAGS+= -D__ST_MT_ERRNO__
 LFLAGS+= -L$(PERLDIR)/CORE -Zstack 16000
 LIBS:= $(PERLDIR)/auto/DynaLoader/DynaLoader.lib \
@@ -37,13 +47,17 @@ endif
 ifdef ZLIB
 COMPRESS=1
 CFLAGS+= -DWITH_ZLIB=1
-ifdef ZLIB_DIR
-CFLAGS+= -I$(ZLIB_DIR)/include
+ifdef ZLIB_BASE
+CFLAGS+= -I$(ZLIB_BASE)
 endif
 ifndef ZLIBDL
-LIBS:=-lz $(LIBS)
-ifdef ZLIB_DIR
-LFLAGS+= -L$(ZLIB_DIR)/lib
+TARGET:=$(TARGET)-zlib
+ifndef ZLIB_LIB
+ZLIB_LIB=z_s
+endif
+LIBS:=-l$(ZLIB_LIB) $(LIBS)
+ifdef ZLIB_BASE
+LFLAGS+= -L$(ZLIB_BASE)
 endif
 endif
 endif
@@ -51,13 +65,17 @@ endif
 ifdef BZLIB2
 COMPRESS=1
 CFLAGS+= -DWITH_BZLIB2=1
-ifdef BZLIB2_DIR
-CFLAGS+= -I$(BZLIB2_DIR)/include
+ifdef BZLIB2_BASE
+CFLAGS+= -I$(BZLIB2_BASE)
 endif
 ifndef ZLIBDL
-LIBS:=-lbz2 $(LIBS)
-ifdef BZLIB2_DIR
-LFLAGS+= -L$(BZLIB2_DIR)/lib
+TARGET:=$(TARGET)-bzlib2
+ifndef BZLIB2_LIB
+BZLIB2_LIB=libbz2
+endif
+LIBS:=-l$(BZLIB2_LIB) $(LIBS)
+ifdef BZLIB2_BASE
+LFLAGS+= -L$(BZLIB2_BASE)
 endif
 endif
 endif
@@ -80,7 +98,9 @@ endif
 
 OBJS=${SRCS:.c=.obj}
 
-all: binkd2eo.exe
+TARGET:=$(TARGET).exe
+
+all: $(TARGET)
 
 .c.obj:
 	@echo Compiling $<...
@@ -88,7 +108,7 @@ all: binkd2eo.exe
 
 .DELETE_ON_ERROR:
 
-binkd2eo.exe: $(OBJS)
+$(TARGET): $(OBJS)
 	@echo Linking $@...
 	@$(CC) -o $@ $(LFLAGS) $(OBJS) $(LIBS)
 

--- a/mkfls/os2-emx/Makefile.klibc
+++ b/mkfls/os2-emx/Makefile.klibc
@@ -3,7 +3,7 @@
 # Makefile for OS/2 GCC using kLIBC (GCC > 3.3.x)
 #
 # Usage: make [DEBUG=1] [NOFORK=1] [PERL=1] [PERLDL=1]
-#             [ZLIB=1] [BZLIB2=1] [ZLIBDL=1] [BW_LIM=1]
+#	      [ZLIB=1] [BZLIB2=1] [ZLIBDL=1] [BW_LIM=1]
 #
 
 CC=gcc
@@ -12,10 +12,15 @@ CFLAGS=$(DEFINES) -Wall -funsigned-char -Wno-char-subscripts
 LFLAGS=
 LIBS=-lsocket
 NTLM_SRC=ntlm/des_enc.c ntlm/helpers.c ntlm/ecb_enc.c ntlm/md4_dgst.c ntlm/set_key.c
-SRCS=binkd.c readcfg.c tools.c ftnaddr.c ftnq.c client.c server.c protocol.c bsy.c inbound.c breaksig.c branch.c os2/gettid.c os2/sem.c  ftndom.c ftnnode.c os2/getfree.c srif.c pmatch.c readflo.c prothlp.c iptools.c rfc2553.c run.c binlog.c exitproc.c getw.c xalloc.c setpttl.c https.c md5b.c crypt.c srv_gai.c os2/ns_parse.c ${NTLM_SRC}
-TARGET=binkd2klibc.exe
+SRCS=binkd.c readcfg.c tools.c ftnaddr.c ftnq.c client.c server.c protocol.c bsy.c inbound.c breaksig.c branch.c os2/gettid.c os2/sem.c ftndom.c ftnnode.c os2/getfree.c srif.c pmatch.c readflo.c prothlp.c iptools.c rfc2553.c run.c binlog.c exitproc.c getw.c xalloc.c setpttl.c https.c md5b.c crypt.c srv_gai.c os2/ns_parse.c ${NTLM_SRC}
+TARGET=binkd2klibc
+
+#PERLDIR=../perl5.00553/os2
+#ZLIB_DIR=../zlib-1.2.11
+#BZLIB2_DIR=../bzip2-1.0.6
 
 ifdef DEBUG
+TARGET:=$(TARGET)-debug
 CFLAGS+=-g -DDEBUG
 LFLAGS+=-g
 else
@@ -24,30 +29,37 @@ LFLAGS+=-O2 -s
 endif
 
 ifdef NOFORK
+TARGET:=$(TARGET)-nofork
 CFLAGS+=-DDEBUGCHILD
 endif
 
 ifdef PERLDL
+TARGET:=$(TARGET)-perldl
+ifndef PERLDIR
 PERLDIR=$(shell perl -MConfig -e "print $$Config{archlib}")
+endif
 CFLAGS+= -Zmt -DWITH_PERL -DPERLDL -DDOSISH -DPERL_IS_AOUT -DEMBED -I$(PERLDIR)/CORE
 LFLAGS+= -Zmt -Zcrtdll -Zstack 16000
 SRCS+= perlhooks.c
 else
 ifdef PERL
+TARGET:=$(TARGET)-perl
+ifndef PERLDIR
 PERLDIR=$(shell perl -MConfig -e "print $$Config{archlib}")
+endif
 CFLAGS+= -DWITH_PERL -DDOSISH -DPERL_IS_AOUT -DEMBED -I$(PERLDIR)/CORE
 LFLAGS+= -L$(PERLDIR)/CORE -Zsmall-conv -Zstack 16000
 LIBS:=$(PERLDIR)/auto/DB_File/DB_File.a \
-         $(PERLDIR)/auto/SDBM_File/SDBM_File.a \
-         $(PERLDIR)/auto/Fcntl/Fcntl.a \
-         $(PERLDIR)/auto/IO/IO.a \
-         $(PERLDIR)/auto/POSIX/POSIX.a \
-         $(PERLDIR)/auto/Socket/Socket.a \
-         $(PERLDIR)/auto/OS2/Process/Process.a \
-         $(PERLDIR)/auto/OS2/ExtAttr/ExtAttr.a \
-         $(PERLDIR)/auto/OS2/REXX/REXX.a \
-         $(PERLDIR)/auto/DynaLoader/DynaLoader.a \
-         -llibperl -lm -lbsd -ldb $(LIBS)
+	 $(PERLDIR)/auto/SDBM_File/SDBM_File.a \
+	 $(PERLDIR)/auto/Fcntl/Fcntl.a \
+	 $(PERLDIR)/auto/IO/IO.a \
+	 $(PERLDIR)/auto/POSIX/POSIX.a \
+	 $(PERLDIR)/auto/Socket/Socket.a \
+	 $(PERLDIR)/auto/OS2/Process/Process.a \
+	 $(PERLDIR)/auto/OS2/ExtAttr/ExtAttr.a \
+	 $(PERLDIR)/auto/OS2/REXX/REXX.a \
+	 $(PERLDIR)/auto/DynaLoader/DynaLoader.a \
+	 -llibperl -lm -lbsd -ldb $(LIBS)
 SRCS+= perlhooks.c
 else
 CFLAGS+= -Zcrtdll
@@ -59,12 +71,16 @@ ifdef ZLIB
 COMPRESS=1
 CFLAGS+= -DWITH_ZLIB=1
 ifdef ZLIB_DIR
-CFLAGS+= -I$(ZLIB_DIR)/include
+CFLAGS+= -I$(ZLIB_DIR)
 endif
 ifndef ZLIBDL
-LIBS:=-lz_s $(LIBS)
+TARGET:=$(TARGET)-zlib
+ifndef ZLIB_LIB
+ZLIB_LIB=z_s
+endif
+LIBS:=-l$(ZLIB_LIB) $(LIBS)
 ifdef ZLIB_DIR
-LFLAGS+= -L$(ZLIB_DIR)/lib
+LFLAGS+= -L$(ZLIB_DIR)
 endif
 endif
 endif
@@ -73,12 +89,16 @@ ifdef BZLIB2
 COMPRESS=1
 CFLAGS+= -DWITH_BZLIB2=1
 ifdef BZLIB2_DIR
-CFLAGS+= -I$(BZLIB2_DIR)/include
+CFLAGS+= -I$(BZLIB2_DIR)
 endif
 ifndef ZLIBDL
-LIBS:=-llibbz2_s $(LIBS)
+TARGET:=$(TARGET)-bzlib2
+ifndef BZLIB2_LIB
+BZLIB2_LIB=libbz2
+endif
+LIBS:=-l$(BZLIB2_LIB) $(LIBS)
 ifdef BZLIB2_DIR
-LFLAGS+= -L$(BZLIB2_DIR)/lib
+LFLAGS+= -L$(BZLIB2_DIR)
 endif
 endif
 endif
@@ -97,6 +117,8 @@ CFLAGS+= -DBW_LIM=1
 endif
 
 OBJS=${SRCS:.c=.o}
+
+TARGET:=$(TARGET).exe
 
 all: $(TARGET)
 

--- a/run.c
+++ b/run.c
@@ -36,6 +36,10 @@
 #define SHELL "cmd.exe"
 #define SHELL_META "\"\'\\%<>|" /* not sure */
 #define SHELLOPT "/c"
+#elif defined(DOS)
+#define SHELL (getenv("COMSPEC") ? getenv("COMSPEC") : "command.com")
+#define SHELL_META "\"\'\\%<>|&^@"
+#define SHELLOPT "/c"
 #else
 #error "Unknown platform"
 #endif

--- a/sys.h
+++ b/sys.h
@@ -95,7 +95,7 @@
       #define PID() ((int)gettid())
     #endif
   #endif
-#elif defined(__MSC__)
+#elif defined(__MSC__) || defined(DJGPP)
   #include <process.h>
   #define PID()    ((int)getpid())
   void dos_sleep(int);


### PR DESCRIPTION
Original patch by Dan Cross,
additional testing and improvements by Max Vasilyev
Neither Win9x nor OS/2 define `struct sockaddr_storage`.
To work around this, we resort to casts to make the
`ss_family` member of that struct look like the `sa_family`
member in a `struct sockaddr`.  According to POSIX, all
of these structs should be defined in such a way that
this will work without surprises.