### PR TITLE
Set correct command line interpreter for Windows in fail situation

### DIFF
--- a/run.c
+++ b/run.c
@@ -65,7 +65,13 @@ int run (char *cmd)
   Log (3, "executing `%s'", cmd);
   memset(&si, 0, sizeof(si));
   si.cb=sizeof(si);
-  if (!sp) sp="command";
+  if (!sp)
+  {
+    if (Is9x())
+      sp="command";
+    else
+      sp="cmd";
+  }
   cs=(char*)malloc(strlen(sp)+strlen(cmd)+6);
   dw=CREATE_DEFAULT_ERROR_MODE;
   strcpy(cs, sp);


### PR DESCRIPTION
Set correct command line interpreter for Windows in fail situation, when COMSPEC= is absent/empty

Signed-off-by: vasilyevmax <35378045+vasilyevmax@users.noreply.github.com>